### PR TITLE
Added command-line parsing (including 'threads' option)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,113 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "digits"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "2.33"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Rust port of a project in .NET (F# & C#). Details of that project are 
 
 This is primarily practice for Rust.
 
-Functions:  
+**Functions**  
 * Reading files from the file system
 * Training simple nearest-neighbor digit recognizers
     * Manhattan distance
@@ -13,7 +13,28 @@ Functions:
 * Output (pretty bad) ASCII art
 * Multi-threading
 * Channels
+* Chunking / threading
+* Parsing command-line parameters
 
-*Note: The threading is pretty ugly, and things are pretty slow right now. But it works. It definitely needs optimization.*  
+**Usage**
+```
+PS C:\...> .\digits.exe --help
+digits 1.0
+Jeremy Clark
+parses hand-written digits
 
-*Update: Okay, so it's slow because I was running the debug version. Running the release version is just as fast as the Go (golang) version.*
+USAGE:
+    digits.exe [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --classifier <classifier>    Classifier to use (default: 'euclidean')
+    -c, --count <count>              Number of records to process (default: 100)
+    -o, --offset <offset>            Offset in the data set (default: 1000)
+    -t, --threads <threads>          Number of threads to use (default: 6)
+```
+
+*Update: Made this a lot faster by adding chunking, which reduces the number of threads to something more practical.*

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,28 +1,65 @@
+extern crate clap;
+
+use clap::{Arg, App};
+
+
 pub struct Config {
     pub offset: usize,
     pub count: usize,
     pub classifier: String,
+    pub threads: usize,
 }
 
 impl Config {
-    pub fn new(args: &[String]) -> Config {
-        let mut offset = "".to_string();
-        let mut count = "".to_string();
-        let mut classifier = "".to_string();
-        if args.len() > 1 {
-            offset = args[1].clone();
-        }
-        if args.len() > 2 {
-            count = args[2].clone();
-        }
-        if args.len() > 3 {
-            classifier = args[3].clone().to_lowercase();
-        }
+    pub fn new() -> Config {
+
+        let app = App::new("digits")
+            .version("1.0")
+            .about("parses hand-written digits")
+            .author("Jeremy Clark");
+
+        let offset_option = Arg::with_name("offset")
+            .short("o")
+            .long("offset") 
+            .takes_value(true)
+            .help("Offset in the data set (default: 1000)")
+            .required(false);
+        let app = app.arg(offset_option);
+
+        let count_option = Arg::with_name("count")
+            .short("c")
+            .long("count") 
+            .takes_value(true)
+            .help("Number of records to process (default: 100)")
+            .required(false);
+        let app = app.arg(count_option);
+
+        let classifier_option = Arg::with_name("classifier")
+            .long("classifier") 
+            .takes_value(true)
+            .help("Classifier to use (default: 'euclidean')")
+            .required(false);
+        let app = app.arg(classifier_option);
+
+        let threads_option = Arg::with_name("threads")
+            .short("t")
+            .long("threads") 
+            .takes_value(true)
+            .help("Number of threads to use (default: 6)")
+            .required(false);
+        let app = app.arg(threads_option);
+
+        let matches = app.get_matches();
+
+        let offset = matches.value_of("offset").unwrap_or_default();
+        let count = matches.value_of("count").unwrap_or_default();
+        let classifier = matches.value_of("classifier").unwrap_or_default();
+        let threads = matches.value_of("threads").unwrap_or_default();
 
         let offset: usize = match offset.trim().parse() {
             Ok(num) => num,
             Err(_) => {
-                println!("Invalid offset, using default (1000)");
+                println!("Offset: using default (1000)");
                 1000
             },
         };
@@ -30,7 +67,7 @@ impl Config {
         let count: usize = match count.trim().parse() {
             Ok(num) => num,
             Err(_) => {
-                println!("Invalid count, using default (100)");
+                println!("Count: using default (100)");
                 100
             },
         };
@@ -41,10 +78,19 @@ impl Config {
             _ => "Euclidean Classifier".to_string(),
         };
 
+        let threads: usize = match threads.trim().parse() {
+            Ok(num) => num,
+            Err(_) => {
+                println!("Threads: using default (6)");
+                6
+            },
+        };
+
         Config {
             offset,
             count,
             classifier,
+            threads,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub fn run(config: configuration::Config) {
 
     let (tx, rx) = mpsc::channel();
 
-    let chunks = loader::chunk_data(validation, 6);
+    let chunks = loader::chunk_data(validation, config.threads);
 
     for chunk in chunks {
         let classifier = match &config.classifier[..] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
-use std::env;
-
 use digits::configuration::Config;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let config = Config::new(&args);
-
+    let config = Config::new();
     digits::run(config);
 }


### PR DESCRIPTION
Command-line parameter parsing for the following:
        --classifier <classifier>    Classifier to use (default: 'euclidean')
    -c, --count <count>              Number of records to process (default: 100)
    -o, --offset <offset>            Offset in the data set (default: 1000)
    -t, --threads <threads>          Number of threads to use (default: 6)
